### PR TITLE
removed limitation where subtypes should be unique (#856)

### DIFF
--- a/adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.java
+++ b/adapters/src/main/java/com/squareup/moshi/adapters/PolymorphicJsonAdapterFactory.java
@@ -154,8 +154,8 @@ public final class PolymorphicJsonAdapterFactory<T> implements JsonAdapter.Facto
   public PolymorphicJsonAdapterFactory<T> withSubtype(Class<? extends T> subtype, String label) {
     if (subtype == null) throw new NullPointerException("subtype == null");
     if (label == null) throw new NullPointerException("label == null");
-    if (labels.contains(label) || subtypes.contains(subtype)) {
-      throw new IllegalArgumentException("Subtypes and labels must be unique.");
+    if (labels.contains(label)) {
+      throw new IllegalArgumentException("Labels must be unique.");
     }
     List<String> newLabels = new ArrayList<>(labels);
     newLabels.add(label);


### PR DESCRIPTION
* removed limitation where subtypes should be unique

There can be use cases where different type labels should match with the same subtype

* added test for PolymorphicJsonAdapter non unique subtypes