### PR TITLE
Switch to openjdk8 for travis builds (#885)

### DIFF
--- a/.buildscript/deploy_snapshot.sh
+++ b/.buildscript/deploy_snapshot.sh
@@ -6,7 +6,7 @@
 # https://benlimmer.com/2013/12/26/automatically-publish-javadoc-to-gh-pages-with-travis-ci/
 
 SLUG="square/moshi"
-JDK="oraclejdk8"
+JDK="openjdk8"
 BRANCH="master"
 
 set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 after_success:
   - .buildscript/deploy_snapshot.sh


### PR DESCRIPTION
* Switch to openjdk8 for travis builds

oraclejdk8 isn't available unless we ust trusty dist, which is also an option

* Update deploy_shapshot.sh