### PR TITLE
Fix incorrect type variance being applied on generated adapters  (#1010)

### DIFF
--- a/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
+++ b/kotlin/codegen/src/main/java/com/squareup/moshi/kotlin/codegen/api/AdapterGenerator.kt
@@ -69,7 +69,7 @@ internal class AdapterGenerator(
 
   private val nameAllocator = NameAllocator()
   private val adapterName = "${className.simpleNames.joinToString(separator = "_")}JsonAdapter"
-  private val originalTypeName = target.typeName
+  private val originalTypeName = target.typeName.stripTypeVarVariance()
   private val originalRawTypeName = originalTypeName.rawType()
 
   private val moshiParam = ParameterSpec.builder(
@@ -130,7 +130,7 @@ internal class AdapterGenerator(
     result.superclass(jsonAdapterTypeName)
 
     if (typeVariables.isNotEmpty()) {
-      result.addTypeVariables(typeVariables)
+      result.addTypeVariables(typeVariables.map { it.stripTypeVarVariance() as TypeVariableName })
     }
 
     // TODO make this configurable. Right now it just matches the source model

--- a/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
+++ b/kotlin/tests/src/test/kotlin/com/squareup/moshi/kotlin/DualKotlinTest.kt
@@ -522,6 +522,24 @@ class DualKotlinTest(useReflection: Boolean) {
       val convolutedMultiNullableShouldBeNullable: NullableB?,
       val deepNestedNullableShouldBeNullable: E
   )
+
+  // Regression test for https://github.com/square/moshi/issues/1009
+  @Test fun outDeclaration() {
+    val adapter = moshi.adapter<OutDeclaration<Int>>()
+
+    @Language("JSON")
+    val testJson = """{"input":3}"""
+
+    val instance = OutDeclaration(3)
+    assertThat(adapter.serializeNulls().toJson(instance))
+        .isEqualTo(testJson)
+
+    val result = adapter.fromJson(testJson)!!
+    assertThat(result).isEqualTo(instance)
+  }
+
+  @JsonClass(generateAdapter = true)
+  data class OutDeclaration<out T>(val input: T)
 }
 
 typealias TypeAlias = Int


### PR DESCRIPTION
* Fix: force object type for type arguments

* Add outDeclaration regression test for #1009

* Create mapTypesUtility for reusing recursive type mapping

* Strip typevar variance where appropriate

Resolves #1009